### PR TITLE
trivial typo on directory of global.css import

### DIFF
--- a/src/app/about/layout.tsx
+++ b/src/app/about/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
-import "./globals.css";
+import "../globals.css";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",

--- a/src/app/calendar/layout.tsx
+++ b/src/app/calendar/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
-import "./globals.css";
+import "../globals.css";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",


### PR DESCRIPTION
from **./global.css** to **../global.css**, only change for about/layout.tsx and calendar/layout.tsx. May have this typo for other components as well (didn't check eheh).